### PR TITLE
feat!: update to version 5 of Mongo driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,20 +32,19 @@
 	</scm>
 
 	<properties>
-		<revision>2.1</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring.version>6.0.4</spring.version>
-		<mongo.version>4.8.2</mongo.version>
-		<slf4j.version>2.0.6</slf4j.version>
+		<spring.version>6.1.4</spring.version>
+		<mongo.version>5.0.0</mongo.version>
+		<slf4j.version>2.0.12</slf4j.version>
 		<gson.version>2.10.1</gson.version>
 		<maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-		<mockito.version>5.1.1</mockito.version>
-		<assertj.version>3.24.2</assertj.version>
-		<junit.version>5.9.2</junit.version>
+		<mockito.version>5.9.0</mockito.version>
+		<assertj.version>3.25.3</assertj.version>
+		<junit.version>5.10.2</junit.version>
 		<hamcrest.version>2.2</hamcrest.version>
-		<logback.verion>1.4.5</logback.verion>
+		<logback.verion>1.5.1</logback.verion>
 		<embedmongo.version>3.0.0</embedmongo.version>
-		<classgraph.version>4.8.154</classgraph.version>
+		<classgraph.version>4.8.165</classgraph.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
A new version of the mongo java client was released (5.0). This version has some breaking changes (https://www.mongodb.com/docs/drivers/java/sync/current/upgrade/#std-label-java-breaking-changes-v5.0), where parts of the API changed on binary level. That means we should compile MigraMongo against this version to ensure that everything is fully compatible! 